### PR TITLE
feat: handle liquid emotion stacks

### DIFF
--- a/ReforgeHelperSettings.cs
+++ b/ReforgeHelperSettings.cs
@@ -43,6 +43,7 @@ namespace ReforgeHelper
         public ToggleNode EnableWaystones { get; set; } = new ToggleNode(true);
         public ToggleNode EnableRelics { get; set; } = new ToggleNode(true);
         public ToggleNode EnableTablets { get; set; } = new ToggleNode(true);
+        public ToggleNode EnableLiquidEmotions { get; set; } = new ToggleNode(true);
     }
 
     [Submenu]


### PR DESCRIPTION
## Summary
- support Liquid Emotions in triplet formation
- repeatedly reforge emotion stacks until depleted and clear bench
- expose Liquid Emotions toggle in settings

## Testing
- `dotnet build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c1d8634afc8332957f99c92a47d6b8