### PR TITLE
Fix stack size retrieval in inventory scanning

### DIFF
--- a/ReforgeHelper.cs
+++ b/ReforgeHelper.cs
@@ -764,7 +764,7 @@ public class ReforgeHelper : BaseSettingsPlugin<ReforgeHelperSettings>
                 var baseComp = item.Item.GetComponent<Base>();
                 var modsComp = item.Item.GetComponent<Mods>();
                 var stackComp = item.Item.GetComponent<Stack>();
-                var stackSize = stackComp?.StackSize ?? 1;
+                var stackSize = stackComp?.Size ?? 1;
 
                 RFLogger.Debug(
                     $"Item: {baseComp?.Name} | Stack: {stackSize} | Level: {modsComp?.ItemLevel} | Rarity: {modsComp?.ItemRarity}"


### PR DESCRIPTION
## Summary
- Replace deprecated StackSize property with Size to read item stack counts

## Testing
- `dotnet build` *(fails: Microsoft.NET.Sdk.WindowsDesktop targets missing)*

------
https://chatgpt.com/codex/tasks/task_e_68c27f6f06d48332aa4f14af713cacd6